### PR TITLE
Поправил проверку train_here для мероприятия

### DIFF
--- a/SwiftUI-WorkoutApp/Screens/Events/Detail/EventDetailsViewModel.swift
+++ b/SwiftUI-WorkoutApp/Screens/Events/Detail/EventDetailsViewModel.swift
@@ -22,7 +22,6 @@ final class EventDetailsViewModel: ObservableObject {
         if !refresh { isLoading.toggle() }
         do {
             event = try await APIService(with: defaults).getEvent(by: event.id)
-            event.trainHere = event.participants.contains(where: { $0.userID == defaults.mainUserInfo?.userID })
         } catch {
             errorMessage = ErrorFilterService.message(from: error)
         }

--- a/SwiftUI-WorkoutApp/Services/APIService.swift
+++ b/SwiftUI-WorkoutApp/Services/APIService.swift
@@ -333,8 +333,7 @@ struct APIService {
     func getEvent(by id: Int) async throws -> EventResponse {
         try await makeResult(
             EventResponse.self,
-            for: Endpoint.getEvent(id: id).urlRequest(with: baseUrlString),
-            needAuth: false
+            for: Endpoint.getEvent(id: id).urlRequest(with: baseUrlString)
         )
     }
 


### PR DESCRIPTION
- Для запроса `getEvent` передаем данные пользователя, чтобы получить корректное значение свойства `train_here`
- Убрал костыль для первичной настройки значения `train_here` через список участников