### PR TITLE
Спрятал лишнюю кнопку на iOS 16

### DIFF
--- a/SwiftUI-WorkoutApp/Screens/Events/List/EventsListView.swift
+++ b/SwiftUI-WorkoutApp/Screens/Events/List/EventsListView.swift
@@ -65,12 +65,10 @@ private extension EventsListView {
         } label: {
             Image(systemName: Icons.Regular.refresh.rawValue)
         }
-        .opacity(refreshButtonOpacity)
+        .opacity(
+            showEmptyView && !DeviceOSVersionChecker.iOS16Available ? 1 : 0
+        )
         .disabled(isLoading)
-    }
-
-    var refreshButtonOpacity: CGFloat {
-        showEmptyView || !DeviceOSVersionChecker.iOS16Available ? 1 : 0
     }
 
     var segmentedControl: some View {


### PR DESCRIPTION
Кнопка "Обновить" на экране мероприятий лишняя на iOS 16+, т.к. есть pull-to-refresh