### PR TITLE
Обновление заголовка для экрана с профилем

### DIFF
--- a/SwiftUI-WorkoutApp/Screens/Profile/Detail/UserDetailsView.swift
+++ b/SwiftUI-WorkoutApp/Screens/Profile/Detail/UserDetailsView.swift
@@ -75,7 +75,7 @@ struct UserDetailsView: View {
         }
         .onDisappear(perform: cancelTasks)
         .task(priority: .userInitiated) { await askForUserInfo() }
-        .navigationTitle(isMainUser ? "" : "Профиль")
+        .navigationTitle("Профиль")
     }
 }
 


### PR DESCRIPTION
Заголовок всегда "Профиль", чтобы в меню у кнопки "назад" не было пустого места