### PR TITLE
Поправил краш календаря (iOS 17+)

### DIFF
--- a/SwiftUI-WorkoutApp.xcodeproj/project.pbxproj
+++ b/SwiftUI-WorkoutApp.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FGU.WorkOut;
 				PRODUCT_NAME = WorkoutApp;
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -522,7 +522,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FGU.WorkOut;
 				PRODUCT_NAME = WorkoutApp;
 				RUN_CLANG_STATIC_ANALYZER = YES;

--- a/SwiftUI-WorkoutApp/Resources/Localizable.xcstrings
+++ b/SwiftUI-WorkoutApp/Resources/Localizable.xcstrings
@@ -2437,12 +2437,12 @@
         }
       }
     },
-    "Необходимо разрешить полный доступ к календарю в настройках телефона" : {
+    "Необходимо разрешить доступ к календарю в настройках телефона" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You need to allow full access to the calendar in your phone settings"
+            "value" : "You need to allow access to the calendar in your phone settings"
           }
         }
       }

--- a/SwiftUI-WorkoutApp/Screens/Events/CalendarManager.swift
+++ b/SwiftUI-WorkoutApp/Screens/Events/CalendarManager.swift
@@ -1,5 +1,6 @@
-import EventKit
+@preconcurrency import EventKit
 import Foundation
+import SWUtils
 
 final class CalendarManager: ObservableObject {
     let eventStore = EKEventStore()
@@ -7,17 +8,16 @@ final class CalendarManager: ObservableObject {
     @Published var showSettingsAlert = false
 
     @MainActor
-    func requestAccess() {
-        switch EKEventStore.authorizationStatus(for: .event) {
-        case .fullAccess: showCalendar = true
-        case .restricted, .denied: showSettingsAlert = true
-        default:
-            eventStore.requestAccess(to: .event) { [weak self] granted, _ in
-                DispatchQueue.main.async {
-                    self?.showCalendar = granted
-                    self?.showSettingsAlert = !granted
-                }
-            }
+    func requestAccess() async throws {
+        let grantedAccess = if #available(iOS 17.0, *) {
+            try await eventStore.requestWriteOnlyAccessToEvents()
+        } else {
+            try await eventStore.requestAccess(to: .event)
+        }
+        if grantedAccess {
+            showCalendar = true
+        } else {
+            showSettingsAlert = true
         }
     }
 }

--- a/SwiftUI-WorkoutApp/Screens/Events/EventDetailsScreen.swift
+++ b/SwiftUI-WorkoutApp/Screens/Events/EventDetailsScreen.swift
@@ -172,24 +172,32 @@ private extension EventDetailsScreen {
     }
 
     var addToCalendarButton: some View {
-        Button("Добавить в календарь", action: calendarManager.requestAccess)
-            .buttonStyle(SWButtonStyle(mode: .tinted, size: .large))
-            .padding(.top, 12)
-            .sheet(isPresented: $calendarManager.showCalendar) {
-                EKEventEditViewControllerRepresentable(
-                    eventStore: calendarManager.eventStore,
-                    event: event
-                )
-            }
-            .alert(
-                "Необходимо разрешить полный доступ к календарю в настройках телефона",
-                isPresented: $calendarManager.showSettingsAlert
-            ) {
-                Button("Отмена", role: .cancel) {}
-                Button("Перейти") {
-                    URLOpener.open(URL(string: UIApplication.openSettingsURLString))
+        Button("Добавить в календарь") {
+            Task {
+                do {
+                    try await calendarManager.requestAccess()
+                } catch {
+                    SWAlert.shared.presentDefaultUIKit(error)
                 }
             }
+        }
+        .buttonStyle(SWButtonStyle(mode: .tinted, size: .large))
+        .padding(.top, 12)
+        .sheet(isPresented: $calendarManager.showCalendar) {
+            EKEventEditViewControllerRepresentable(
+                eventStore: calendarManager.eventStore,
+                event: event
+            )
+        }
+        .alert(
+            "Необходимо разрешить доступ к календарю в настройках телефона",
+            isPresented: $calendarManager.showSettingsAlert
+        ) {
+            Button("Отмена", role: .cancel) {}
+            Button("Перейти") {
+                URLOpener.open(URL(string: UIApplication.openSettingsURLString))
+            }
+        }
     }
 
     var descriptionSection: some View {


### PR DESCRIPTION
В iOS 17 нужно по-новому запрашивать доступ для добавления событий в календарь, а старый способ приводит к крашу как раз на iOS 17+. Теперь будет 2 варианта запроса доступа, пока не откажемся от iOS < 17.