### PR TITLE
Поправил обновление адреса

### DIFF
--- a/SwiftUI-WorkoutApp/Libraries/SWModels/Sources/SWModels/Park/NewParkMapModel.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWModels/Sources/SWModels/Park/NewParkMapModel.swift
@@ -96,6 +96,17 @@ public struct NewParkMapModel: Sendable, Equatable {
         )
     }
 
+    /// Создает модель с обнуленным адресом для принудительного геокодирования
+    /// - Returns: Модель с пустым адресом, остальные поля не изменяются
+    public func withoutAddress() -> Self {
+        Self(
+            coordinate: coordinate,
+            lastLocationRequestDate: lastLocationRequestDate,
+            address: "",
+            cityId: cityId
+        )
+    }
+
     public static let empty = Self(
         coordinate: .init(latitude: 0, longitude: 0),
         lastLocationRequestDate: nil,

--- a/SwiftUI-WorkoutApp/Libraries/SWModels/Tests/SWModelsTest/NewParkMapModelTests.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWModels/Tests/SWModelsTest/NewParkMapModelTests.swift
@@ -239,4 +239,68 @@ struct NewParkMapModelTests {
         #expect(modelWithZeroLongitude.shouldRequestLocation)
         #expect(modelWithZeroCoordinates.shouldRequestLocation)
     }
+
+    @Test("Проверка метода withoutAddress - обнуляет адрес но сохраняет остальные данные")
+    func withoutAddressResetsAddressButPreservesOtherData() {
+        let coordinate = CLLocationCoordinate2D(latitude: 55.7539, longitude: 37.6208)
+        let date = Date()
+        let originalModel = SUT(
+            coordinate: coordinate,
+            lastLocationRequestDate: date,
+            address: "Москва, Красная площадь",
+            cityId: 1
+        )
+        let modelWithoutAddress = originalModel.withoutAddress()
+        #expect(modelWithoutAddress.address.isEmpty)
+        #expect(modelWithoutAddress.coordinate.latitude == coordinate.latitude)
+        #expect(modelWithoutAddress.coordinate.longitude == coordinate.longitude)
+        #expect(modelWithoutAddress.lastLocationRequestDate == date)
+        #expect(modelWithoutAddress.cityId == 1)
+    }
+
+    @Test("Проверка метода withoutAddress с пустым адресом")
+    func withoutAddressWithEmptyAddress() {
+        let coordinate = CLLocationCoordinate2D(latitude: 55.7539, longitude: 37.6208)
+        let originalModel = SUT(
+            coordinate: coordinate,
+            address: "",
+            cityId: 5
+        )
+        let modelWithoutAddress = originalModel.withoutAddress()
+        #expect(modelWithoutAddress.address.isEmpty)
+        #expect(modelWithoutAddress.coordinate.latitude == coordinate.latitude)
+        #expect(modelWithoutAddress.coordinate.longitude == coordinate.longitude)
+        #expect(modelWithoutAddress.cityId == 5)
+        #expect(modelWithoutAddress.lastLocationRequestDate == nil)
+    }
+
+    @Test("Проверка shouldPerformGeocode после withoutAddress")
+    func shouldPerformGeocodeAfterWithoutAddress() {
+        let originalModel = SUT(
+            coordinate: .init(latitude: 55.7539, longitude: 37.6208),
+            address: "Москва, Красная площадь",
+            cityId: 1
+        )
+        #expect(!originalModel.shouldPerformGeocode, "Изначально геокодирование не требуется")
+        let modelWithoutAddress = originalModel.withoutAddress()
+        #expect(modelWithoutAddress.shouldPerformGeocode, "После обнуления адреса геокодирование требуется")
+    }
+
+    @Test("Проверка withoutAddress не влияет на isEmpty")
+    func withoutAddressDoesNotAffectIsEmpty() {
+        let nonEmptyModel = SUT(
+            coordinate: .init(latitude: 55.7539, longitude: 37.6208),
+            address: "Тестовый адрес",
+            cityId: 1
+        )
+        let emptyModel = SUT(
+            coordinate: .init(latitude: 0, longitude: 0),
+            address: "Тестовый адрес",
+            cityId: 1
+        )
+        #expect(!nonEmptyModel.isEmpty)
+        #expect(!nonEmptyModel.withoutAddress().isEmpty)
+        #expect(emptyModel.isEmpty)
+        #expect(emptyModel.withoutAddress().isEmpty)
+    }
 }

--- a/SwiftUI-WorkoutApp/Screens/Parks/Map/ParksMapScreen+ViewModel.swift
+++ b/SwiftUI-WorkoutApp/Screens/Parks/Map/ParksMapScreen+ViewModel.swift
@@ -121,7 +121,7 @@ extension ParksMapScreen {
 
         /// Запрашивает локацию для создания новой площадки
         func requestLocationForNewPark() {
-            var currentModel = newParkState.model
+            var currentModel = newParkState.model.withoutAddress()
             if let cache = getValidGeocodingCache(for: currentModel.coordinate) {
                 logger.debug("Используем кешированные данные геокодирования")
                 currentModel = currentModel.withGeocodingData(


### PR DESCRIPTION
При нажатии на кнопку создания площадки всегда сначала обнуляем адрес в модели новой площадки, а уже потом подставляем адрес либо из кэша геокодера, либо геокодируем с нуля