### PR TITLE
Рефактор

### DIFF
--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1273.0)
-    aws-sdk-core (3.254.0)
+    aws-partitions (1.1279.0)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -20,8 +20,8 @@ GEM
     aws-sdk-kms (1.130.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.228.1)
-      aws-sdk-core (~> 3, >= 3.254.0)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -35,14 +35,14 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    csv (3.3.5)
+    csv (3.3.6)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
-    excon (1.6.0)
+    excon (1.7.0)
       logger
     faraday (1.10.6)
       faraday-em_http (~> 1.0)
@@ -126,7 +126,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.105.0)
+    google-apis-androidpublisher_v3 (0.106.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (0.18.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -159,7 +159,7 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-logging-utils (0.2.0)
-    googleauth (1.17.2)
+    googleauth (1.17.3)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -173,7 +173,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -248,10 +248,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1273.0) sha256=b4b794a077c9fc943f67d1cc37cb6ec817af558d070a6cf350050ec8c8906f70
-  aws-sdk-core (3.254.0) sha256=ee3e3220b8468a3c9e59daba18e6ec897bf5c7ce8adcc0670cfa2f1f092112fe
+  aws-partitions (1.1279.0) sha256=9baa4f75bca3e5efe4d4df27655ae640aaaa1f6e2d3cf59fda3dad19689ae435
+  aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
   aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
-  aws-sdk-s3 (1.228.1) sha256=8865f6c6d068a9713a2aa6fe8107d11b0020a93cd5110b3994526bd9560f553e
+  aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -261,13 +261,13 @@ CHECKSUMS
   colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
   colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
   commander (4.6.0) sha256=7d1ddc3fccae60cc906b4131b916107e2ef0108858f485fdda30610c0f2913d9
-  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
   dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
   emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
-  excon (1.6.0) sha256=ebe2ab83c055ef8e117c62c91a3535b966a59a64868188219d49ab90cd83b65f
+  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
   faraday (1.10.6) sha256=7ff4802a6b312876a2241b3e641ce0d5045e168dd871b422c35b505e5261ad4d
   faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
   faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
@@ -285,7 +285,7 @@ CHECKSUMS
   fastlane (2.237.0) sha256=bb1e867bc070fb328741b5e6e7606d5ba596941a9ecca0478f60ef22d1009db9
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
-  google-apis-androidpublisher_v3 (0.105.0) sha256=31afbbf2512def8f6605238554d1a1274158539374e1d602a37bce41fc07a6b4
+  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
   google-apis-core (0.18.0) sha256=96b057816feeeab448139ed5b5c78eab7fc2a9d8958f0fbc8217dedffad054ee
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
@@ -295,12 +295,12 @@ CHECKSUMS
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  googleauth (1.17.2) sha256=1869110ea20edef3be155f63827a5ad1b71558df164a31895b2b07a65ed87fc7
+  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Street Workout Площадки
 
 <!-- BEGIN_VERSIONS -->
-[<img alt="Xcode Version" src="https://img.shields.io/badge/Xcode_Version-27.0-blue">](https://developer.apple.com/xcode/)
+[<img alt="Xcode Version" src="https://img.shields.io/badge/Xcode_Version-26.6-blue">](https://developer.apple.com/xcode/)
 [<img alt="Swift Version" src="https://img.shields.io/badge/Swift_Version-6.3.0-orange">](https://swift.org)
 [<img alt="iOS Version" src="https://img.shields.io/badge/iOS_Version-16.0-4F9153">](https://www.apple.com/ios/)
 <!-- END_VERSIONS -->

--- a/SwiftUI-WorkoutApp/EnvironmentKeys/AnalyticsServiceEnvironmentKey.swift
+++ b/SwiftUI-WorkoutApp/EnvironmentKeys/AnalyticsServiceEnvironmentKey.swift
@@ -1,5 +1,5 @@
 import SwiftUI
 
 extension EnvironmentValues {
-    @Entry var analyticsService = AnalyticsService(providers: [NoopAnalyticsProvider()])
+    @Entry var analyticsService = AnalyticsService()
 }

--- a/SwiftUI-WorkoutApp/Libraries/CachedAsyncImage/Sources/CachedAsyncImage/Internal/ImageLoader.swift
+++ b/SwiftUI-WorkoutApp/Libraries/CachedAsyncImage/Sources/CachedAsyncImage/Internal/ImageLoader.swift
@@ -1,11 +1,6 @@
 import UIKit.UIImage
 
-protocol ImageLoaderProtocol: Sendable {
-    func loadImage(for url: URL?) async throws -> UIImage
-    func getCachedImage(for url: URL?) -> UIImage?
-}
-
-struct ImageLoader: ImageLoaderProtocol {
+struct ImageLoader: Sendable {
     private let cache: ImageCacheProtocol
     private let urlSession: URLSession
 

--- a/SwiftUI-WorkoutApp/Libraries/CachedAsyncImage/Sources/CachedAsyncImage/Public/CachedAsyncImage.swift
+++ b/SwiftUI-WorkoutApp/Libraries/CachedAsyncImage/Sources/CachedAsyncImage/Public/CachedAsyncImage.swift
@@ -7,7 +7,7 @@ public struct CachedAsyncImage<Content: View, Placeholder: View>: View {
         subsystem: Bundle.main.bundleIdentifier ?? "CachedAsyncImage",
         category: "View"
     )
-    private let loader: ImageLoaderProtocol = ImageLoader()
+    private let loader = ImageLoader()
     private let transition: AnyTransition
     private let placeholder: Placeholder
     private let content: (UIImage) -> Content

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Internal/HTTPHeaderField.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Internal/HTTPHeaderField.swift
@@ -1,4 +1,0 @@
-struct HTTPHeaderField: Equatable {
-    let key: String
-    let value: String
-}

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/APIError.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/APIError.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public enum APIError: Error, LocalizedError, Equatable {
-    case noData
     case unknown
     case badRequest
     case invalidCredentials
@@ -10,7 +9,6 @@ public enum APIError: Error, LocalizedError, Equatable {
     case serverError
     case invalidUserId
     case customError(code: Int, message: String)
-    case decodingError
     case notConnectedToInternet
 
     init(_ error: ErrorResponse, _ statusCode: Int?) {
@@ -58,8 +56,6 @@ public enum APIError: Error, LocalizedError, Equatable {
 
     public var errorDescription: String? {
         switch self {
-        case .noData:
-            String(localized: .errorNoData)
         case .unknown:
             String(localized: .errorUnknown)
         case .badRequest:
@@ -76,8 +72,6 @@ public enum APIError: Error, LocalizedError, Equatable {
             String(localized: .errorInvalidUserID)
         case let .customError(code, error):
             "\(code), \(error)"
-        case .decodingError:
-            String(localized: .errorDecoding)
         case .notConnectedToInternet:
             String(localized: .errorNoInternet)
         }

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/BodyMaker.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/BodyMaker.swift
@@ -2,43 +2,28 @@ import Foundation
 
 /// Делает `body` для запроса
 public enum BodyMaker {
-    struct Parameter {
-        let key: String
-        let value: String
-
-        init(from element: Dictionary<String, String>.Element) {
-            self.key = element.key
-            self.value = element.value
-        }
-
-        init(key: String, value: String) {
-            self.key = key
-            self.value = value
-        }
-    }
-
-    /// Делает `body` из словаря
+    /// Делает `body` из словаря (порядок стабилен — по ключу)
     static func makeBody(
-        with parameters: [Parameter]
+        with parameters: [String: String]
     ) -> Data? {
-        parameters.isEmpty
-            ? nil
-            : parameters
-                .map { $0.key + "=" + $0.value }
-                .joined(separator: "&")
-                .data(using: .utf8)
+        guard !parameters.isEmpty else { return nil }
+        return parameters
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
     }
 
-    /// Делает `body` из словаря и медиа-файлов
+    /// Делает `body` из словаря и медиа-файлов (порядок параметров стабилен — по ключу)
     static func makeBodyWithMultipartForm(
-        parameters: [Parameter],
+        parameters: [String: String],
         media: [MediaFile]?,
         boundary: String
     ) -> Data? {
         let lineBreak = "\r\n"
         var body = Data()
         if !parameters.isEmpty {
-            parameters.forEach { element in
+            parameters.sorted { $0.key < $1.key }.forEach { element in
                 body.append("--\(boundary)\(lineBreak)")
                 body.append("Content-Disposition: form-data; name=\"\(element.key)\"\(lineBreak + lineBreak)")
                 body.append("\(element.value)\(lineBreak)")
@@ -64,11 +49,11 @@ public enum BodyMaker {
 public extension BodyMaker {
     /// Модель для последующего создания тела запроса
     struct Parts {
-        let parameters: [Parameter]
+        let parameters: [String: String]
         let mediaFiles: [MediaFile]?
 
         public init(_ parameters: [String: String], _ mediaFiles: [MediaFile]?) {
-            self.parameters = parameters.map(Parameter.init)
+            self.parameters = parameters
             self.mediaFiles = mediaFiles
         }
     }

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/RequestComponents.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/RequestComponents.swift
@@ -55,7 +55,7 @@ extension RequestComponents {
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod.rawValue
 
-        var allHeaders = [HTTPHeaderField]()
+        var allHeaders: [String: String] = [:]
         var httpBodyData: Data?
 
         if let bodyParts {
@@ -66,24 +66,19 @@ extension RequestComponents {
                     media: bodyParts.mediaFiles,
                     boundary: boundary
                 )
-                allHeaders.append(.init(
-                    key: "Content-Type",
-                    value: "multipart/form-data; boundary=\(boundary)"
-                ))
+                allHeaders["Content-Type"] = "multipart/form-data; boundary=\(boundary)"
             } else {
                 httpBodyData = BodyMaker.makeBody(with: parameters)
             }
             if let httpBodyData {
-                allHeaders.append(.init(key: "Content-Length", value: "\(httpBodyData.count)"))
+                allHeaders["Content-Length"] = "\(httpBodyData.count)"
             }
         }
 
         if let token, !token.isEmpty {
-            allHeaders.append(.init(key: "Authorization", value: "Basic \(token)"))
+            allHeaders["Authorization"] = "Basic \(token)"
         }
-        request.allHTTPHeaderFields = Dictionary(
-            uniqueKeysWithValues: allHeaders.map { ($0.key, $0.value) }
-        )
+        request.allHTTPHeaderFields = allHeaders
         request.httpBody = httpBodyData
         return request
     }

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/SWNetwork.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Sources/SWNetwork/Public/SWNetwork.swift
@@ -1,14 +1,12 @@
 import Foundation
 import OSLog
 
-public protocol SWNetworkProtocol: Sendable {
-    /// Делает запрос и возвращает данные в ответе
+public protocol NetworkServicing: Sendable {
     func requestData<T: Decodable>(components: RequestComponents) async throws -> T
-    /// Делает запрос для проверки статуса операции, в случае успеха ничего не возвращает
     func requestStatus(components: RequestComponents) async throws
 }
 
-public struct SWNetworkService {
+public struct SWNetworkService: NetworkServicing {
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "SWNetworkService",
         category: String(describing: SWNetworkService.self)
@@ -27,8 +25,8 @@ public struct SWNetworkService {
     }
 }
 
-extension SWNetworkService: SWNetworkProtocol {
-    public func requestData<T: Decodable>(components: RequestComponents) async throws -> T {
+public extension SWNetworkService {
+    func requestData<T: Decodable>(components: RequestComponents) async throws -> T {
         guard let request = components.urlRequest else {
             throw APIError.badRequest
         }
@@ -60,7 +58,7 @@ extension SWNetworkService: SWNetworkProtocol {
         }
     }
 
-    public func requestStatus(components: RequestComponents) async throws {
+    func requestStatus(components: RequestComponents) async throws {
         guard let request = components.urlRequest else {
             throw APIError.badRequest
         }

--- a/SwiftUI-WorkoutApp/Libraries/SWNetwork/Tests/SWNetworkTests/BodyMakerTests.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetwork/Tests/SWNetworkTests/BodyMakerTests.swift
@@ -3,36 +3,24 @@ import Foundation
 import Testing
 
 struct BodyMakerTests {
-    @Test
-    func parameterInitializationFromDictionaryElement() {
-        let element = ("testKey", "testValue")
-        let parameter = BodyMaker.Parameter(from: element)
-        #expect(parameter.key == "testKey")
-        #expect(parameter.value == "testValue")
-    }
-
     // MARK: - makeBody
 
     @Test
     func makeBodyWithNoParametersReturnsNil() {
-        let result = BodyMaker.makeBody(with: [])
+        let result = BodyMaker.makeBody(with: [:])
         #expect(result == nil)
     }
 
     @Test
     func makeBodyWithSingleParameter() throws {
-        let parameter = BodyMaker.Parameter(key: "name", value: "John")
-        let result = try #require(BodyMaker.makeBody(with: [parameter]))
+        let result = try #require(BodyMaker.makeBody(with: ["name": "John"]))
         let expectedString = "name=John"
         #expect(String(data: result, encoding: .utf8) == expectedString)
     }
 
     @Test
     func makeBodyWithMultipleParameters() throws {
-        let params = [
-            BodyMaker.Parameter(key: "a", value: "1"),
-            BodyMaker.Parameter(key: "b", value: "2")
-        ]
+        let params = ["a": "1", "b": "2"]
         let result = try #require(BodyMaker.makeBody(with: params))
         let expectedString = "a=1&b=2"
         #expect(String(data: result, encoding: .utf8) == expectedString)
@@ -43,7 +31,7 @@ struct BodyMakerTests {
     @Test
     func multipartFormWithNoContentReturnsNil() {
         let result = BodyMaker.makeBodyWithMultipartForm(
-            parameters: [],
+            parameters: [:],
             media: nil,
             boundary: "BOUNDARY"
         )
@@ -52,10 +40,9 @@ struct BodyMakerTests {
 
     @Test
     func multipartFormWithParametersOnly() throws {
-        let params = [BodyMaker.Parameter(key: "text", value: "Hello")]
         let boundary = "TESTBOUNDARY"
         let result = try #require(BodyMaker.makeBodyWithMultipartForm(
-            parameters: params,
+            parameters: ["text": "Hello"],
             media: nil,
             boundary: boundary
         ))
@@ -83,7 +70,7 @@ struct BodyMakerTests {
         ]
         let boundary = "MEDIA_BOUNDARY"
         let result = try #require(BodyMaker.makeBodyWithMultipartForm(
-            parameters: [],
+            parameters: [:],
             media: media,
             boundary: boundary
         ))
@@ -102,7 +89,6 @@ struct BodyMakerTests {
 
     @Test
     func multipartFormWithMixedContent() throws {
-        let params = [BodyMaker.Parameter(key: "title", value: "Document")]
         let media = [
             BodyMaker.MediaFile(
                 key: "doc",
@@ -113,7 +99,7 @@ struct BodyMakerTests {
         ]
         let boundary = "MIXEDBOUNDARY"
         let result = try #require(BodyMaker.makeBodyWithMultipartForm(
-            parameters: params,
+            parameters: ["title": "Document"],
             media: media,
             boundary: boundary
         ))

--- a/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/AllClients.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/AllClients.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-/// Композиция всех протоколов клиентов для работы с API
-public typealias AllClients = AuthClient & CommentsClient & CountriesClient & EventsClient & FriendsClient & JournalsClient &
-    MessagesClient & ParksClient & PhotosClient & ProfileClient

--- a/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/Protocols/AuthClient.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/Protocols/AuthClient.swift
@@ -18,8 +18,7 @@ public protocol AuthClient: Sendable {
 extension SWClient: AuthClient {
     public func logIn(with token: String?) async throws -> Int {
         let endpoint = Endpoint.login
-        let finalComponents = try await makeComponents(for: endpoint, with: token)
-        let result: LoginResponse = try await service.requestData(components: finalComponents)
+        let result: LoginResponse = try await makeResult(for: endpoint, with: token)
         return result.userId
     }
 

--- a/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/SWClient.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWNetworkClient/Sources/SWNetworkClient/SWClient.swift
@@ -6,24 +6,27 @@ import SWNetwork
 public struct SWClient: Sendable {
     let authHelper: AuthHelper
     /// Сервис для отправки запросов/получения ответов от сервера
-    let service: SWNetworkProtocol
+    let service: any NetworkServicing
 
     /// Инициализатор
     /// - Parameter authHelper: Сервис, предоставляющий токен авторизации,
     /// и выполняющий логаут при необходимости
     public init(with authHelper: AuthHelper) {
+        self.init(with: authHelper, service: SWNetworkService())
+    }
+
+    init(with authHelper: AuthHelper, service: any NetworkServicing) {
         self.authHelper = authHelper
-        self.service = SWNetworkService()
+        self.service = service
     }
 }
 
 // MARK: - Обертки для SWNetworkService
 
 extension SWClient {
-    func makeStatus(for endpoint: Endpoint) async throws {
+    private func mapErrors<T>(_ work: () async throws -> T) async throws -> T {
         do {
-            let finalComponents = try await makeComponents(for: endpoint)
-            try await service.requestStatus(components: finalComponents)
+            return try await work()
         } catch APIError.invalidCredentials {
             await authHelper.triggerLogout()
             throw ClientError.forceLogout
@@ -36,22 +39,20 @@ extension SWClient {
         }
     }
 
+    func makeStatus(for endpoint: Endpoint) async throws {
+        try await mapErrors {
+            let finalComponents = try await makeComponents(for: endpoint)
+            try await service.requestStatus(components: finalComponents)
+        }
+    }
+
     func makeResult<T: Decodable>(
         for endpoint: Endpoint,
         with token: String? = nil
     ) async throws -> T {
-        do {
+        try await mapErrors {
             let finalComponents = try await makeComponents(for: endpoint, with: token)
             return try await service.requestData(components: finalComponents)
-        } catch APIError.invalidCredentials {
-            await authHelper.triggerLogout()
-            throw ClientError.forceLogout
-        } catch APIError.notConnectedToInternet {
-            throw ClientError.noConnection
-        } catch APIError.notFound {
-            throw ClientError.notFound
-        } catch {
-            throw error
         }
     }
 

--- a/SwiftUI-WorkoutApp/Libraries/SWUtils/Sources/SWUtils/SWFileManagerImp.swift
+++ b/SwiftUI-WorkoutApp/Libraries/SWUtils/Sources/SWUtils/SWFileManagerImp.swift
@@ -29,15 +29,13 @@ public struct SWFileManagerImp: Sendable, SWFileManager {
     /// Проверяет существование сохраненного файла
     public var documentExists: Bool {
         let path = documentDirectoryURL.appendingPathComponent(fileName).path()
-        return FileManager().fileExists(atPath: path)
+        return FileManager.default.fileExists(atPath: path)
     }
 
     /// Сохраняет `Encodable`-объект
     public func save(_ object: some Encodable) throws {
-        let encodedData = try JSONEncoder().encode(object)
-        let jsonString = String(decoding: encodedData, as: UTF8.self)
         let url = documentDirectoryURL.appendingPathComponent(fileName)
-        try jsonString.write(to: url, atomically: true, encoding: .utf8)
+        try JSONEncoder().encode(object).write(to: url, options: .atomic)
     }
 
     /// Загружает данные из ранее сохраненного файла

--- a/SwiftUI-WorkoutApp/Screens/Common/FeedbackHelper.swift
+++ b/SwiftUI-WorkoutApp/Screens/Common/FeedbackHelper.swift
@@ -1,0 +1,24 @@
+import SWDesignSystem
+import SWModels
+import SWUtils
+
+@MainActor
+extension ItemListScreen.Mode {
+    /// Общий обработчик для кнопки "Написать нам" на экранах выбора страны/города.
+    func sendFeedback(
+        source: AnalyticsEvent.AppScreen,
+        analytics: AnalyticsService,
+        sender: FeedbackSender.Type = FeedbackSender.self
+    ) {
+        analytics.log(.userAction(action: .sendFeedback(source: source)))
+        let (subject, body) = switch self {
+        case .city: (LocationFeedback.city.subject, LocationFeedback.city.body)
+        case .country: (LocationFeedback.country.subject, LocationFeedback.country.body)
+        }
+        sender.sendFeedback(
+            subject: subject,
+            messageBody: body,
+            recipients: Constants.feedbackRecipient
+        )
+    }
+}

--- a/SwiftUI-WorkoutApp/Screens/Common/LoginScreen.swift
+++ b/SwiftUI-WorkoutApp/Screens/Common/LoginScreen.swift
@@ -104,11 +104,11 @@ private extension LoginScreen {
         loginTask = Task {
             do {
                 #if DEBUG
-                let client: AllClients = Constants.isUITest
+                let client: AuthClient & ProfileClient = Constants.isUITest
                     ? MockSWClient(instantResponse: true)
                     : SWClient(with: defaults.authHelper)
                 #else
-                let client: AllClients = SWClient(with: defaults.authHelper)
+                let client: AuthClient & ProfileClient = SWClient(with: defaults.authHelper)
                 #endif
                 let model = AuthData(login: credentials.login, password: credentials.password)
                 let userId = try await client.logIn(with: model.token)

--- a/SwiftUI-WorkoutApp/Screens/Messages/DialogsListScreen+ViewModel.swift
+++ b/SwiftUI-WorkoutApp/Screens/Messages/DialogsListScreen+ViewModel.swift
@@ -13,7 +13,7 @@ extension DialogsListScreen {
         init(
             isUITest: Bool = false,
             authHelper: AuthHelper,
-            analytics: AnalyticsService = AnalyticsService(providers: [NoopAnalyticsProvider()])
+            analytics: AnalyticsService = AnalyticsService()
         ) {
             self.isUITest = isUITest
             self.authHelper = authHelper

--- a/SwiftUI-WorkoutApp/Screens/Parks/Map/ParksMapScreen.swift
+++ b/SwiftUI-WorkoutApp/Screens/Parks/Map/ParksMapScreen.swift
@@ -373,16 +373,7 @@ private extension ParksMapScreen {
     }
 
     func sendFeedback(mode: ItemListScreen.Mode) {
-        analytics.log(.userAction(action: .sendFeedback(source: .parksMap)))
-        let (subject, body) = switch mode {
-        case .city: (LocationFeedback.city.subject, LocationFeedback.city.body)
-        case .country: (LocationFeedback.country.subject, LocationFeedback.country.body)
-        }
-        FeedbackSender.sendFeedback(
-            subject: subject,
-            messageBody: body,
-            recipients: Constants.feedbackRecipient
-        )
+        mode.sendFeedback(source: .parksMap, analytics: analytics)
     }
 
     // MARK: - Обновление кэша

--- a/SwiftUI-WorkoutApp/Screens/Profile/EditProfile/EditProfileScreen.swift
+++ b/SwiftUI-WorkoutApp/Screens/Profile/EditProfile/EditProfileScreen.swift
@@ -292,20 +292,11 @@ private extension EditProfileScreen {
     }
 
     func sendFeedback(mode: ItemListScreen.Mode) {
-        let source = switch mode {
-        case .city: AnalyticsEvent.AppScreen.cityList
-        case .country: AnalyticsEvent.AppScreen.countryList
+        let source: AnalyticsEvent.AppScreen = switch mode {
+        case .city: .cityList
+        case .country: .countryList
         }
-        analytics.log(.userAction(action: .sendFeedback(source: source)))
-        let (subject, body) = switch mode {
-        case .city: (LocationFeedback.city.subject, LocationFeedback.city.body)
-        case .country: (LocationFeedback.country.subject, LocationFeedback.country.body)
-        }
-        FeedbackSender.sendFeedback(
-            subject: subject,
-            messageBody: body,
-            recipients: Constants.feedbackRecipient
-        )
+        mode.sendFeedback(source: source, analytics: analytics)
     }
 }
 

--- a/SwiftUI-WorkoutApp/Screens/Profile/MainUserProfileScreen+ViewModel.swift
+++ b/SwiftUI-WorkoutApp/Screens/Profile/MainUserProfileScreen+ViewModel.swift
@@ -16,7 +16,7 @@ extension MainUserProfileScreen {
 
         init(
             isUITest: Bool = false,
-            analytics: AnalyticsService = AnalyticsService(providers: [NoopAnalyticsProvider()])
+            analytics: AnalyticsService = AnalyticsService()
         ) {
             self.isUITest = isUITest
             self.analytics = analytics

--- a/SwiftUI-WorkoutApp/Services/Analytics/AnalyticsService.swift
+++ b/SwiftUI-WorkoutApp/Services/Analytics/AnalyticsService.swift
@@ -1,15 +1,13 @@
 import Foundation
 
 struct AnalyticsService {
-    private let providers: [any AnalyticsProvider]
+    private let provider: (any AnalyticsProvider)?
 
-    init(providers: [any AnalyticsProvider] = []) {
-        self.providers = providers
+    init(provider: (any AnalyticsProvider)? = nil) {
+        self.provider = provider
     }
 
     func log(_ event: AnalyticsEvent) {
-        for provider in providers {
-            provider.log(event: event)
-        }
+        provider?.log(event: event)
     }
 }

--- a/SwiftUI-WorkoutApp/Services/Analytics/NoopAnalyticsProvider.swift
+++ b/SwiftUI-WorkoutApp/Services/Analytics/NoopAnalyticsProvider.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct NoopAnalyticsProvider: AnalyticsProvider {
-    func log(event _: AnalyticsEvent) {}
-}

--- a/SwiftUI-WorkoutApp/Services/DefaultsService.swift
+++ b/SwiftUI-WorkoutApp/Services/DefaultsService.swift
@@ -120,7 +120,7 @@ final class DefaultsService: ObservableObject {
 
     func getUserPassword() throws -> String {
         guard let authHelperImp = authHelper as? AuthHelperImp else {
-            throw StorageError.noAuthData
+            throw AuthHelperImp.StorageError.noAuthData
         }
         return try authHelperImp.getUserPassword()
     }
@@ -199,18 +199,6 @@ extension DefaultsService {
             hasParks: hasParks,
             hasFriends: hasFriends
         )
-    }
-}
-
-extension DefaultsService {
-    enum StorageError: Error, LocalizedError {
-        case noAuthData
-
-        var errorDescription: String? {
-            switch self {
-            case .noAuthData: "В keychain нет данных авторизации"
-            }
-        }
     }
 }
 

--- a/SwiftUI-WorkoutApp/SwiftUI_WorkoutAppApp.swift
+++ b/SwiftUI-WorkoutApp/SwiftUI_WorkoutAppApp.swift
@@ -40,15 +40,15 @@ struct SwiftUI_WorkoutAppApp: App {
         #if DEBUG
         authHelper = isUITest ? MockAuthHelper() : AuthHelperImp()
         analyticsService = isUITest
-            ? AnalyticsService(providers: [NoopAnalyticsProvider()])
-            : AnalyticsService(providers: [FirebaseAnalyticsProvider()])
+            ? AnalyticsService()
+            : AnalyticsService(provider: FirebaseAnalyticsProvider())
         if isUITest {
             UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
             UIView.setAnimationsEnabled(false)
         }
         #else
         authHelper = AuthHelperImp()
-        analyticsService = AnalyticsService(providers: [FirebaseAnalyticsProvider()])
+        analyticsService = AnalyticsService(provider: FirebaseAnalyticsProvider())
         #endif
         _defaults = .init(wrappedValue: .init(authHelper: authHelper))
         _parksManager = .init(

--- a/WorkoutAppTests/Mocks/MockSWNetworkService.swift
+++ b/WorkoutAppTests/Mocks/MockSWNetworkService.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SWNetwork
+
+final class MockSWNetworkService: NetworkServicing, @unchecked Sendable {
+    var errorToThrow: Error?
+
+    func requestData<T: Decodable>(components _: RequestComponents) async throws -> T {
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        throw MockError.noDataConfigured
+    }
+
+    func requestStatus(components _: RequestComponents) async throws {
+        if let errorToThrow {
+            throw errorToThrow
+        }
+    }
+}
+
+extension MockSWNetworkService {
+    /// Ошибка для тестирования
+    enum MockError: Error {
+        case noDataConfigured
+    }
+}

--- a/WorkoutAppTests/SWClientMapErrorsTests.swift
+++ b/WorkoutAppTests/SWClientMapErrorsTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SWNetwork
+@testable import SWNetworkClient
+import Testing
+
+@Suite("SWClient.mapErrors — маппинг APIError в ClientError")
+@MainActor
+struct SWClientMapErrorsTests {
+    struct MapErrorsCase {
+        let apiError: APIError
+        let expectedClientError: ClientError?
+        let expectedLogoutCallCount: Int
+    }
+
+    @Test("Должен мапить APIError в ClientError и дёргать triggerLogout только на 401", arguments: [
+        MapErrorsCase(apiError: .invalidCredentials, expectedClientError: .forceLogout, expectedLogoutCallCount: 1),
+        MapErrorsCase(apiError: .notFound, expectedClientError: .notFound, expectedLogoutCallCount: 0),
+        MapErrorsCase(apiError: .notConnectedToInternet, expectedClientError: .noConnection, expectedLogoutCallCount: 0),
+        MapErrorsCase(apiError: .unknown, expectedClientError: nil, expectedLogoutCallCount: 0)
+    ])
+    func mapErrors(testCase: MapErrorsCase) async throws {
+        let authHelper = MockAuthHelperForDefaultsService()
+        let mockService = MockSWNetworkService()
+        mockService.errorToThrow = testCase.apiError
+        let client = SWClient(with: authHelper, service: mockService)
+
+        if let expected = testCase.expectedClientError {
+            await #expect(throws: expected) {
+                _ = try await client.makeStatus(for: .login)
+            }
+        } else {
+            await #expect(throws: testCase.apiError) {
+                _ = try await client.makeStatus(for: .login)
+            }
+        }
+
+        #expect(authHelper.triggerLogoutCallCount == testCase.expectedLogoutCallCount)
+    }
+
+    @Test("Должен считать каждый вызов triggerLogout независимо при повторных 401")
+    func repeatedInvalidCredentialsCountsEachLogout() async throws {
+        let authHelper = MockAuthHelperForDefaultsService()
+        let mockService = MockSWNetworkService()
+        mockService.errorToThrow = APIError.invalidCredentials
+        let client = SWClient(with: authHelper, service: mockService)
+
+        await #expect(throws: ClientError.forceLogout) {
+            _ = try await client.makeStatus(for: .login)
+        }
+        await #expect(throws: ClientError.forceLogout) {
+            _ = try await client.makeStatus(for: .login)
+        }
+
+        #expect(authHelper.triggerLogoutCallCount == 2)
+    }
+}

--- a/WorkoutAppTests/Services/Analytics/AnalyticsServiceTests.swift
+++ b/WorkoutAppTests/Services/Analytics/AnalyticsServiceTests.swift
@@ -11,53 +11,25 @@ private final class AnalyticsProviderSpy: AnalyticsProvider {
 }
 
 struct AnalyticsServiceTests {
-    @Test("fan-out отправляет событие во все провайдеры")
+    @Test("безопасная работа при пустом провайдере (nil)")
     @MainActor
-    func log_sendsEventToAllProviders() {
-        let spy1 = AnalyticsProviderSpy()
-        let spy2 = AnalyticsProviderSpy()
-        let service = AnalyticsService(providers: [spy1, spy2])
+    func log_doesNotThrowWithEmptyProviders() {
+        let service = AnalyticsService()
+        service.log(AnalyticsEvent.screenView(screen: .root))
+    }
+
+    @Test("логирование вызывает провайдер")
+    @MainActor
+    func log_callsProvider() {
+        let spy = AnalyticsProviderSpy()
+        let service = AnalyticsService(provider: spy)
 
         let event = AnalyticsEvent.screenView(screen: .parksMap)
         service.log(event)
 
-        #expect(spy1.loggedEvents.count == 1)
-        #expect(spy2.loggedEvents.count == 1)
+        #expect(spy.loggedEvents.count == 1)
+        #expect(spy.loggedEvents.first?.actionName == "parks_map")
     }
-
-    @Test("fan-out сохраняет порядок отправки")
-    @MainActor
-    func log_preservesOrder() {
-        let spy1 = AnalyticsProviderSpy()
-        let spy2 = AnalyticsProviderSpy()
-        let service = AnalyticsService(providers: [spy1, spy2])
-
-        let event = AnalyticsEvent.userAction(action: .login)
-        service.log(event)
-
-        #expect(spy1.loggedEvents.first?.actionName == "login")
-        #expect(spy2.loggedEvents.first?.actionName == "login")
-    }
-
-    @Test("безопасная работа при пустом массиве провайдеров")
-    @MainActor
-    func log_doesNotThrowWithEmptyProviders() {
-        let service = AnalyticsService(providers: [])
-        service.log(AnalyticsEvent.screenView(screen: .root))
-    }
-
-    @Test("NoopAnalyticsProvider не падает на любых событиях")
-    @MainActor
-    func noopProvider_doesNotThrow() {
-        let provider = NoopAnalyticsProvider()
-        provider.log(event: AnalyticsEvent.screenView(screen: .login))
-        provider.log(event: AnalyticsEvent.userAction(action: .login))
-        provider.log(event: AnalyticsEvent.appError(kind: .loginFailed, error: AnalyticsServiceMockError.sample))
-    }
-}
-
-private enum AnalyticsServiceMockError: Error {
-    case sample
 }
 
 private extension AnalyticsEvent {

--- a/docs/analytics-architecture.md
+++ b/docs/analytics-architecture.md
@@ -20,8 +20,7 @@
 - Провайдерная схема:
   - `AnalyticsProvider` (протокол)
   - `FirebaseAnalyticsProvider` (отправка в Firebase)
-  - `NoopAnalyticsProvider` (тесты/превью/UITest-конфигурации)
-- `AnalyticsService` делает fan-out во все подключенные провайдеры.
+- `AnalyticsService` делегирует событие в единственный подключенный провайдер.
 
 ## 3. Интеграция и DI
 


### PR DESCRIPTION
- Удалены мёртвые и избыточные абстракции: NoopAnalyticsProvider, ImageLoaderProtocol, SWNetworkProtocol, AllClients, HTTPHeaderField, DefaultsService.StorageError, APIError.noData/.decodingError — всего 7 сущностей с одним имплементация или без вызывающих, плюс упрощены сигнатуры BodyMaker.Parameter, SWFileManagerImp.save, mapErrors (вместо makeStatus/makeResult).
- Сокращён AnalyticsService с массива провайдеров до single optional provider, добавлен общий helper sendFeedback(mode:) вместо 12-16 строк дублей на двух экранах (ParksMapScreen, EditProfileScreen) — единая точка входа с аналитическим событием.
- Извлечён NetworkServicing: Sendable, добавлен MockSWNetworkService, suite @MainActor с параметризованным @Test (4 кейса маппинга APIError → ClientError + тест повторных 401)